### PR TITLE
Let String.fromCString() handle nil.

### DIFF
--- a/Sources/Environment/Environment.swift
+++ b/Sources/Environment/Environment.swift
@@ -10,11 +10,7 @@ public struct Environment {
 
     public func getVar(name: String) -> String? {
         let out = getenv(name)
-        if out != nil {
-            return String.fromCString(out)
-        } else {
-            return nil
-        }
+        return String.fromCString(out)
     }
 
     public func removeVar(name: String) {
@@ -25,7 +21,4 @@ public struct Environment {
         setenv(name, value, replace ? 1 : 0)
     }
 }
-
-
-
 


### PR DESCRIPTION
No need to check for nil since the `String.fromCString(_:)` method can do it
for us. If nil is passed the function will return nil.

[Docs for `String.fromCString(_:)` ](https://developer.apple.com/library/ios/documentation/Swift/Reference/Swift_String_Structure/index.html#//apple_ref/swift/structcm/String/s:ZFSS11fromCStringFMSSFGVSs13UnsafePointerVSs4Int8_GSqSS_)
