### PR TITLE
Make `all` method a little more idiomatic

### DIFF
--- a/Sources/Environment/Environment.swift
+++ b/Sources/Environment/Environment.swift
@@ -44,17 +44,18 @@ public struct Environment {
     public func all() -> [String: String] {
         var env = environ
         var pairs: [String: String] = [:]
-        while true {
-            guard let cval = env?.pointee else { break }
-            let pairString = String(cString: cval)
+        while let cpair = env?.pointee {
+            defer { env = env?.successor() }
+
+            let pairString = String(cString: cpair)
             let pair = pairString
-                .characters
+                .unicodeScalars
                 .split(separator: "=", maxSplits: 2, omittingEmptySubsequences: false)
                 .map(String.init)
+
             if pair.count == 2 {
                 pairs[pair[0]] = pair[1]
             }
-            env = env?.advanced(by: 1)
         }
         return pairs
     }

--- a/Sources/Environment/Environment.swift
+++ b/Sources/Environment/Environment.swift
@@ -49,7 +49,7 @@ public struct Environment {
 
             let pairString = String(cString: cpair)
             let pair = pairString
-                .unicodeScalars
+                .characters
                 .split(separator: "=", maxSplits: 2, omittingEmptySubsequences: false)
                 .map(String.init)
 


### PR DESCRIPTION
- `while let` instead of `while true`+`break`
- split on unicodeScalars instead of characters (major perf improvement)
- use `successor` instead of `advanced(by: 1)`
